### PR TITLE
Fix BrowserSync proxy for node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./out/browsersync.plugin.js",
   "dependencies": {
-    "browser-sync": "^1.2.1"
+    "browser-sync": "^2.6.4"
   },
   "devDependencies": {
     "coffee-script": "~1.6.2",

--- a/src/browsersync.plugin.coffee
+++ b/src/browsersync.plugin.coffee
@@ -11,8 +11,9 @@ module.exports = (BasePlugin) ->
         serverAfter: (opts) ->
             address = opts.serverHttp.address()
             serverHostname = address.address
+            serverHostname = 'localhost' if serverHostname == '::'
             serverPort = address.port
-            serverLocation = "http://" + serverHostname + ":" + serverPort + "/";
+            serverLocation = 'http://' + serverHostname + ':' + serverPort + '/';
             @browserSync = require('browser-sync')
             bsConfig = @getConfig()
             bsConfig.proxy = serverLocation


### PR DESCRIPTION
Hey @terminalpixel,

Awesome plugin!

I've ran into an issue using Node 0.12.x where the proxy server address is incorrect and never connects to BrowserSync. This appears to be because the server address returned can be a IPv6 instance.

I've added a little patch that will resolve to `localhost` so that both IPv4 and IPv6 server connections will work. This appears to be how BrowserSync handles it as well (I'm new to IPv6 so it what I've said doesn't sound right, that's probably why).

I've also bumped the version of BrowserSync ahead to 2.6.4. A lot of great features landed and it would be nice to have access to them.

Cheers,
Michael