### PR TITLE
Fix proxying of 0.0.0.0 instead of localhost

### DIFF
--- a/src/browsersync.plugin.coffee
+++ b/src/browsersync.plugin.coffee
@@ -11,7 +11,7 @@ module.exports = (BasePlugin) ->
         serverAfter: (opts) ->
             address = opts.serverHttp.address()
             serverHostname = address.address
-            serverHostname = 'localhost' if serverHostname == '::'
+            serverHostname = 'localhost' if serverHostname == '::' || '0.0.0.0'
             serverPort = address.port
             serverLocation = 'http://' + serverHostname + ':' + serverPort + '/';
             @browserSync = require('browser-sync')


### PR DESCRIPTION
`docpad run` on Windows 10 with default options:
...
info: Server started on http://0.0.0.0:9778
info: In your web browser use http://127.0.0.1:9778
...
Browsersync ends up proxying 0.0.0.0 rather than localhost, which doesn't work.